### PR TITLE
Modifed the way mpi's pkg_name, version and build is specified

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
         - make
     run:
         - cudatoolkit {{ cudatoolkit }}
-        - mpi 1.0 openmpi
+        - mpi=1.0=openmpi
 
 test:
     requires:


### PR DESCRIPTION
in deps section.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

The way we had specified `mpi` in meta.yaml was causing problem with conda env file generation logic. So, better is we specify it this way so that pkg_name, version and build string are properly parsed and read.
Also this is how mpi is listed when we export the environment which has openmpi installed.