### PR TITLE
Fix activate.sh

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 3
+    number: 4
     string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
     script_env:
       - CUDA_HOME

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -2,11 +2,11 @@
 
 if [ ! -z "$OPAL_PREFIX" ]
 then
-    export OPEN_MPI_OPAL_PREFIX_OLD =$OPAL_PREFIX
+    export OPEN_MPI_OPAL_PREFIX_OLD="$OPAL_PREFIX"
 fi
 if [ ! -z "$MPI_ROOT" ]
 then
-    export OPEN_MPI_MPI_ROOT_OLD=$MPI_ROOT
+    export OPEN_MPI_MPI_ROOT_OLD="$MPI_ROOT"
 fi
-export OPAL_PREFIX=$CONDA_PREFIX
-export MPI_ROOT=$CONDA_PREFIX
+export OPAL_PREFIX="$CONDA_PREFIX"
+export MPI_ROOT="$CONDA_PREFIX"

--- a/scripts/deactivate.sh
+++ b/scripts/deactivate.sh
@@ -2,14 +2,14 @@
 
 if [ ! -z "$OPEN_MPI_OPAL_PREFIX_OLD" ]
 then
-    export OPAL_PREFIX=$OPEN_MPI_OPAL_PREFIX_OLD
+    export OPAL_PREFIX="$OPEN_MPI_OPAL_PREFIX_OLD"
     unset OPEN_MPI_OPAL_PREFIX_OLD
 else
     unset OPAL_PREFIX
 fi
 if [ ! -z "$OPEN_MPI_MPI_ROOT_OLD" ]
 then
-    export MPI_ROOT=$OPEN_MPI_MPI_ROOT_OLD
+    export MPI_ROOT="$OPEN_MPI_MPI_ROOT_OLD"
     unset OPEN_MPI_MPI_ROOT_OLD
 else
     unset MPI_ROOT


### PR DESCRIPTION
The typo on line 5 of activate.sh was preventing horovod from building.

I'm not sure how this worked before.