### PR TITLE
[1.5] update run_tests.sh to use tests from current directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 3
+    number: 4
 {% if build_type == 'cuda' %}
     string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
     script_env:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -17,7 +17,7 @@
 
 set -e
 
-pushd $RECIPE_DIR/tests
+pushd ./tests
 
 mpicc helloworld.c -o helloworld_c
 mpirun --allow-run-as-root -n 4 ./helloworld_c


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

`RECIPE_DIR` is not available during tests phase as we are building the packages with `--no-include-recipe` (https://github.com/open-ce/open-ce-builder/pull/141). Using path relative to current directory works. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
