### PR TITLE
use perl 5.26.2 for s390x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 4
+    number: 5
 {% if build_type == 'cuda' %}
     string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
     script_env:
@@ -21,7 +21,8 @@ build:
 
 requirements:
     build:
-        - perl 5.26.0
+        - perl 5.26.0            #[not s390x]
+        - perl 5.26.2            #[s390x]
         - {{ compiler('c') }}    #[ppc_arch != "p10"]
         - {{ compiler('cxx') }}  #[ppc_arch != "p10"]
         - make


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

This PR sets `perl `pin to 5.26.2 for s390x as 5.26.0 is not available on it and does not change the pin for other platforms as the builds for x86 and PPC are already done.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
